### PR TITLE
Add tests and documentation for ASP.NET Core controller registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,40 @@ It adds MediatR requests handlers, although you might need to add other types li
 public static partial IServiceCollection AddRepositories(this IServiceCollection services);
 ```
 
+### Register ASP.NET Core controllers as services
+By default, ASP.NET Core controllers are not registered in the DI container — they are instantiated using an activator. However, if you want controllers to be resolved from DI (equivalent to calling `AddControllersAsServices()`), you can register them with `ServiceScan`:
+```csharp
+[GenerateServiceRegistrations(
+    AssignableTo = typeof(ControllerBase),
+    AsSelf = true,
+    Lifetime = ServiceLifetime.Transient)]
+public static partial IServiceCollection AddControllersAsServices(this IServiceCollection services);
+```
+This discovers all classes inheriting from `ControllerBase` and registers each one as a transient service with its concrete type. You can then combine this with `services.AddControllers()`:
+```csharp
+services.AddControllers();
+services.AddControllersAsServices();
+```
+This gives you full DI control over controllers — allowing lifetime customization, decoration, or replacement of individual controllers.
+
+You can also use `TypeNameFilter` to discover controllers by naming convention instead:
+```csharp
+[GenerateServiceRegistrations(
+    TypeNameFilter = "*Controller",
+    AsSelf = true,
+    Lifetime = ServiceLifetime.Transient)]
+public static partial IServiceCollection AddControllersAsServices(this IServiceCollection services);
+```
+
+And you can exclude specific controllers using `ExcludeByTypeName`:
+```csharp
+[GenerateServiceRegistrations(
+    AssignableTo = typeof(ControllerBase),
+    AsSelf = true,
+    ExcludeByTypeName = "*InternalController")]
+public static partial IServiceCollection AddControllersAsServices(this IServiceCollection services);
+```
+
 ### Add AspNetCore Minimal API endpoints
 You can add custom type handler, if you need to do something non-trivial with that type. For example, you can automatically discover
 and map Minimal API endpoints:

--- a/ServiceScan.SourceGenerator.Tests/AddServicesTests.cs
+++ b/ServiceScan.SourceGenerator.Tests/AddServicesTests.cs
@@ -1073,6 +1073,123 @@ public class AddServicesTests
     }
 
     [Fact]
+    public void AddAspNetCoreControllersAsServices()
+    {
+        var attribute = """[GenerateServiceRegistrations(AssignableTo = typeof(ControllerBase), AsSelf = true, Lifetime = ServiceLifetime.Transient)]""";
+
+        var compilation = CreateCompilation(
+            Sources.MethodWithAttribute(attribute),
+            """
+            namespace GeneratorTests;
+
+            public abstract class ControllerBase { }
+            public abstract class Controller : ControllerBase { }
+            public class HomeController : Controller { }
+            public class AccountController : Controller { }
+            """);
+
+        var results = CSharpGeneratorDriver
+            .Create(_generator)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var registrations = $"""
+            return services
+                .AddTransient<global::GeneratorTests.HomeController, global::GeneratorTests.HomeController>()
+                .AddTransient<global::GeneratorTests.AccountController, global::GeneratorTests.AccountController>();
+            """;
+        Assert.Equal(Sources.GetMethodImplementation(registrations), results.GeneratedTrees[2].ToString());
+    }
+
+    [Fact]
+    public void AddAspNetCoreControllersAsServicesWithTypeNameFilter()
+    {
+        var attribute = """[GenerateServiceRegistrations(TypeNameFilter = "*Controller", AsSelf = true, Lifetime = ServiceLifetime.Transient)]""";
+
+        var compilation = CreateCompilation(
+            Sources.MethodWithAttribute(attribute),
+            """
+            namespace GeneratorTests;
+
+            public abstract class ControllerBase { }
+            public abstract class Controller : ControllerBase { }
+            public class HomeController : Controller { }
+            public class AccountController : Controller { }
+            public class NotAControllerService { }
+            """);
+
+        var results = CSharpGeneratorDriver
+            .Create(_generator)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var registrations = $"""
+            return services
+                .AddTransient<global::GeneratorTests.HomeController, global::GeneratorTests.HomeController>()
+                .AddTransient<global::GeneratorTests.AccountController, global::GeneratorTests.AccountController>();
+            """;
+        Assert.Equal(Sources.GetMethodImplementation(registrations), results.GeneratedTrees[2].ToString());
+    }
+
+    [Fact]
+    public void AddAspNetCoreControllersAsScopedServices()
+    {
+        var attribute = """[GenerateServiceRegistrations(AssignableTo = typeof(ControllerBase), AsSelf = true, Lifetime = ServiceLifetime.Scoped)]""";
+
+        var compilation = CreateCompilation(
+            Sources.MethodWithAttribute(attribute),
+            """
+            namespace GeneratorTests;
+
+            public abstract class ControllerBase { }
+            public abstract class Controller : ControllerBase { }
+            public class HomeController : Controller { }
+            public class AccountController : Controller { }
+            """);
+
+        var results = CSharpGeneratorDriver
+            .Create(_generator)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var registrations = $"""
+            return services
+                .AddScoped<global::GeneratorTests.HomeController, global::GeneratorTests.HomeController>()
+                .AddScoped<global::GeneratorTests.AccountController, global::GeneratorTests.AccountController>();
+            """;
+        Assert.Equal(Sources.GetMethodImplementation(registrations), results.GeneratedTrees[2].ToString());
+    }
+
+    [Fact]
+    public void AddAspNetCoreControllersWithExclusion()
+    {
+        var attribute = """[GenerateServiceRegistrations(AssignableTo = typeof(ControllerBase), AsSelf = true, ExcludeByTypeName = "*Account*")]""";
+
+        var compilation = CreateCompilation(
+            Sources.MethodWithAttribute(attribute),
+            """
+            namespace GeneratorTests;
+
+            public abstract class ControllerBase { }
+            public abstract class Controller : ControllerBase { }
+            public class HomeController : Controller { }
+            public class AccountController : Controller { }
+            public class AccountSettingsController : Controller { }
+            """);
+
+        var results = CSharpGeneratorDriver
+            .Create(_generator)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var registrations = $"""
+            return services
+                .AddTransient<global::GeneratorTests.HomeController, global::GeneratorTests.HomeController>();
+            """;
+        Assert.Equal(Sources.GetMethodImplementation(registrations), results.GeneratedTrees[2].ToString());
+    }
+
+    [Fact]
     public void DontGenerateAnythingIfTypeIsInvalid()
     {
         var attribute = $"[GenerateServiceRegistrations(AssignableTo = typeof(IWrongService))]";


### PR DESCRIPTION
This pull request adds support for registering ASP.NET Core controllers as services using the `ServiceScan` source generator. It introduces new documentation and comprehensive tests to demonstrate and verify controller registration by base type, naming convention, lifetime, and exclusion.

**Documentation improvements:**

* Added a new section to `README.md` explaining how to register controllers as services with `ServiceScan`, including usage examples for filtering by base type, naming convention, and exclusions.

**Test coverage for controller registration:**

* Added tests to `AddServicesTests.cs` verifying that controllers inheriting from `ControllerBase` are registered as services with the correct lifetime and type.
* Added tests for registering controllers using a `TypeNameFilter` (e.g., `*Controller`) to match by naming convention.
* Added tests to ensure controllers can be registered with a custom lifetime (e.g., `Scoped`).
* Added tests to verify controllers can be excluded from registration using `ExcludeByTypeName` (e.g., excluding `*Account*`).