### PR TITLE
Fix: handle array / pointer / dynamic type arguments in nested constraint chains

### DIFF
--- a/ServiceScan.SourceGenerator.Tests/CustomHandlerTests.cs
+++ b/ServiceScan.SourceGenerator.Tests/CustomHandlerTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
-using System.Threading.Tasks;
 
 namespace ServiceScan.SourceGenerator.Tests;
 
@@ -1076,6 +1076,71 @@ public class CustomHandlerTests
                 {
                     HandleType<global::GeneratorTests.SmthX>();
                     HandleType<global::GeneratorTests.SmthY>();
+                }
+            }
+            """;
+        await Assert.That(results.GeneratedTrees[2].ToString()).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task CustomHandler_HandlesArrayTypeArgumentInNestedConstraint()
+    {
+        // Regression: MatchedTypeSatisfiesConstraints used to bail on non-INamedTypeSymbol
+        // candidate type arguments, silently dropping handlers whose bound generic contains
+        // an array (e.g. IHandler<Q, byte[]> where the callback constrains Q : IQuery<TResult>).
+        var source = """
+            using ServiceScan.SourceGenerator;
+
+            namespace GeneratorTests;
+
+            public static partial class ServiceCollectionExtensions
+            {
+                [GenerateServiceRegistrations(AssignableTo = typeof(IHandler<,>), CustomHandler = nameof(AddHandler))]
+                public static partial void AddHandlers();
+
+                private static void AddHandler<THandler, TQuery, TResult>()
+                    where THandler : class, IHandler<TQuery, TResult>
+                    where TQuery : class, IQuery<TResult>
+                {
+                }
+            }
+            """;
+
+        var services = """
+            namespace GeneratorTests;
+
+            public interface IQuery<T> { }
+            public interface IHandler<TQuery, TResult> where TQuery : IQuery<TResult> { }
+
+            public class BytesQuery : IQuery<byte[]> { }
+            public class JaggedBytesQuery : IQuery<byte[][]> { }
+            public class StringsQuery : IQuery<string[]> { }
+            public class ScalarQuery : IQuery<int> { }
+
+            public class BytesHandler : IHandler<BytesQuery, byte[]> { }
+            public class JaggedBytesHandler : IHandler<JaggedBytesQuery, byte[][]> { }
+            public class StringsHandler : IHandler<StringsQuery, string[]> { }
+            public class ScalarHandler : IHandler<ScalarQuery, int> { }
+            """;
+
+        var compilation = CreateCompilation(source, services);
+
+        var results = CSharpGeneratorDriver
+            .Create(_generator)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var expected = """
+            namespace GeneratorTests;
+
+            public static partial class ServiceCollectionExtensions
+            {
+                public static partial void AddHandlers()
+                {
+                    AddHandler<global::GeneratorTests.BytesHandler, global::GeneratorTests.BytesQuery, byte[]>();
+                    AddHandler<global::GeneratorTests.JaggedBytesHandler, global::GeneratorTests.JaggedBytesQuery, byte[][]>();
+                    AddHandler<global::GeneratorTests.StringsHandler, global::GeneratorTests.StringsQuery, string[]>();
+                    AddHandler<global::GeneratorTests.ScalarHandler, global::GeneratorTests.ScalarQuery, int>();
                 }
             }
             """;

--- a/ServiceScan.SourceGenerator/DependencyInjectionGenerator.FilterTypes.cs
+++ b/ServiceScan.SourceGenerator/DependencyInjectionGenerator.FilterTypes.cs
@@ -304,13 +304,31 @@ public partial class DependencyInjectionGenerator
 
             for (var i = 0; i < constraintType.TypeArguments.Length; i++)
             {
-                if (matchedType.TypeArguments[i] is not INamedTypeSymbol candidateTypeArgument)
-                    return false;
+                var candidateTypeArgument = matchedType.TypeArguments[i];
 
                 if (constraintType.TypeArguments[i] is ITypeParameterSymbol typeParameter)
                 {
-                    if (!SatisfiesGenericConstraints(candidateTypeArgument, typeParameter, customHandlerMethod, visitedTypeParameters))
-                        return false;
+                    if (candidateTypeArgument is INamedTypeSymbol namedCandidate)
+                    {
+                        if (!SatisfiesGenericConstraints(namedCandidate, typeParameter, customHandlerMethod, visitedTypeParameters))
+                            return false;
+                    }
+                    else
+                    {
+                        // Non-named types (arrays, pointers, dynamic). Can't recurse into nested constraints,
+                        // but the simple constraints on typeParameter still apply.
+                        if (typeParameter.HasValueTypeConstraint) return false;
+                        if (typeParameter.HasUnmanagedTypeConstraint) return false;
+                        if (typeParameter.HasConstructorConstraint) return false;
+                        if (typeParameter.HasReferenceTypeConstraint && candidateTypeArgument.IsValueType) return false;
+
+                        foreach (var constraint in typeParameter.ConstraintTypes.OfType<INamedTypeSymbol>())
+                        {
+                            if (!candidateTypeArgument.AllInterfaces.Contains(constraint, SymbolEqualityComparer.Default)
+                                && !SymbolEqualityComparer.Default.Equals(candidateTypeArgument.BaseType, constraint))
+                                return false;
+                        }
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

`MatchedTypeSatisfiesConstraints` in `DependencyInjectionGenerator.FilterTypes.cs` requires every candidate type argument in a nested constraint chain to be an `INamedTypeSymbol`. When the recursion reaches a constructed generic whose type argument is an array (`T[]`, `T[][]`), pointer, or `dynamic`, the pattern-match fails and the whole handler is silently dropped from generation — no diagnostic, no warning.

## Repro (fails on `main`)

```csharp
using ServiceScan.SourceGenerator;

namespace Repro;

public static partial class Registrations
{
    [GenerateServiceRegistrations(AssignableTo = typeof(IHandler<,>), CustomHandler = nameof(AddHandler))]
    public static partial void AddHandlers();

    private static void AddHandler<THandler, TQuery, TResult>()
        where THandler : class, IHandler<TQuery, TResult>
        where TQuery   : class, IQuery<TResult>
    {
    }
}

public interface IQuery<T> { }
public interface IHandler<TQuery, TResult> where TQuery : IQuery<TResult> { }

public class BytesQuery       : IQuery<byte[]>   { }
public class JaggedBytesQuery : IQuery<byte[][]> { }
public class ScalarQuery      : IQuery<int>      { }

public class BytesHandler       : IHandler<BytesQuery,       byte[]>   { }
public class JaggedBytesHandler : IHandler<JaggedBytesQuery, byte[][]> { }
public class ScalarHandler      : IHandler<ScalarQuery,      int>      { }
```

**Expected emit:** all three `AddHandler<...>()` calls.
**Actual emit:** only `AddHandler<ScalarHandler, ScalarQuery, int>();` — the two array-result handlers are silently dropped.

## Root cause

`MatchedTypeSatisfiesConstraints` walks `THandler`'s constraint chain recursively. On the outer step it matches `THandler : IHandler<TQuery, TResult>` fine. Then it recurses into `TQuery : IQuery<TResult>` by walking `BytesQuery.AllInterfaces` for `IQuery<byte[]>`. That step compares constraint type args with matched-interface type args:

```csharp
if (matchedType.TypeArguments[i] is not INamedTypeSymbol candidateTypeArgument)
    return false;
```

`matchedType.TypeArguments[0] = byte[]` is an `IArrayTypeSymbol`, not `INamedTypeSymbol`, so the pattern-match fails and the whole outer handler is rejected.

## Fix

Widen the check to `ITypeSymbol` and branch on shape:
- `INamedTypeSymbol` candidate → recurse into `SatisfiesGenericConstraints` as before.
- Other `ITypeSymbol` (array, pointer, dynamic) → can't recurse into nested constraints, but the simple constraints (`class` / `struct` / `new()` / interface / base-class) on the type parameter still apply. Reject `struct`, `unmanaged`, `new()`; honor `class`; and check interface / base-class constraint types against the candidate's `AllInterfaces` + `BaseType`.

## Test

`CustomHandlerTests.CustomHandler_HandlesArrayTypeArgumentInNestedConstraint` covers `byte[]`, `byte[][]`, `string[]`, and `int`. Verified: fails on `main`, passes with the fix; all 94 existing tests still pass.

## Impact

Any consumer using `CustomHandler` (or `ScanForTypes+Handler`) with a nested-generic constraint chain and array-typed generic arguments — I hit it in production migrating a large CQRS codebase where `IAsyncQueryHandler<Q, byte[]>` handlers silently disappeared from DI after switching to source-gen.
